### PR TITLE
Standardising controller responses

### DIFF
--- a/HabitTracker.Application/Models/Responses/ApiResponse.cs
+++ b/HabitTracker.Application/Models/Responses/ApiResponse.cs
@@ -1,0 +1,17 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace HabitTracker.Application.Models.Responses
+{
+    public class ApiResponse<T>
+    {
+        public required T Data { get; set; }
+        public string? Message { get; set; }
+        public required bool Success { get; set; }
+        public required HttpStatusCode ErrorCode { get; set; }
+    }
+}

--- a/HabitTracker/Controllers/Base/BaseController.cs
+++ b/HabitTracker/Controllers/Base/BaseController.cs
@@ -1,9 +1,36 @@
-﻿using Microsoft.AspNetCore.Mvc;
+﻿using HabitTracker.Application.Models.Responses;
+using Microsoft.AspNetCore.Mvc;
+using System.Net;
 
 namespace HabitTracker.API.Controllers.Base
 {
     [ApiController]
     public class BaseController : Controller
     {
+        protected static OkObjectResult Success<T>(T data)
+        {
+            return new OkObjectResult(new ApiResponse<T>
+            {
+                Data = data,
+                Success = true,
+                ErrorCode = HttpStatusCode.OK
+            });
+        }
+
+        protected static ObjectResult Fail(HttpStatusCode code, string message)
+        {
+            ApiResponse<string> response = new()
+            {
+                Data = "",
+                Message = message,
+                Success = false,
+                ErrorCode = code
+            };
+
+            return new ObjectResult(response)
+            {
+                StatusCode = (int)code
+            };
+        }
     }
 }

--- a/HabitTracker/Controllers/HabitTaskController.cs
+++ b/HabitTracker/Controllers/HabitTaskController.cs
@@ -15,7 +15,7 @@ namespace HabitTracker.API.Controllers
         [HttpGet("")]
         public IActionResult GetData()
         {
-            return Ok(new { message = "you have hit the endpoint" });
+            return Success("you have hit the endpoint");
         }
     }
 }


### PR DESCRIPTION
- Added success and fail methods to base controller for DRY response.
- Swapped test endpoint over to using success method.
- Created apiresponse object for standardising data transfer.